### PR TITLE
Vertex issue fix

### DIFF
--- a/janusgraph-cdc-extension/src/main/java/org/sunbird/janusgraph/cdc/SunbirdLegacyMessageConverter.java
+++ b/janusgraph-cdc-extension/src/main/java/org/sunbird/janusgraph/cdc/SunbirdLegacyMessageConverter.java
@@ -114,7 +114,15 @@ public class SunbirdLegacyMessageConverter implements MessageConverter {
         map.put("channel", getVertexProperty(vertex, "channel", "all"));
         map.put("label", getLabel(vertex));
         map.put("nodeType", getVertexProperty(vertex, "IL_SYS_NODE_TYPE", "DATA_NODE"));
-        map.put("objectType", getVertexProperty(vertex, "IL_FUNC_OBJECT_TYPE", vertex.label()));
+        String objectType = getVertexProperty(vertex, "IL_FUNC_OBJECT_TYPE", vertex.label());
+        // Filter out internal JanusGraph vertices that have no IL_FUNC_OBJECT_TYPE set
+        // (their label falls back to TinkerPop's default "vertex")
+        if ("vertex".equalsIgnoreCase(objectType)) {
+            logger.debug("Skipping event for vertex {} with objectType='vertex' (no IL_FUNC_OBJECT_TYPE set)",
+                    vertex.id());
+            return null;
+        }
+        map.put("objectType", objectType);
         map.put("nodeUniqueId", getVertexProperty(vertex, "IL_UNIQUE_ID", vertex.id().toString()));
         map.put("userId", getUserId(vertex));
 


### PR DESCRIPTION
Change - 

it will skip all events (CREATE, UPDATE, DELETE) for any vertex where IL_FUNC_OBJECT_TYPE is not set, causing objectType to fall back to "vertex".

That's the intended behavior. These are internal JanusGraph vertices (no IL_FUNC_OBJECT_TYPE means they're not real content objects). The event you showed confirms this — the vertex had no meaningful properties in transactionData either (properties: {}).

If you're worried about missing legitimate DELETE events for real content nodes, those nodes will have IL_FUNC_OBJECT_TYPE set (e.g., "Content", "Collection") so they won't be filtered out.