### PR TITLE
fix: Handle CDC race condition when vertex deleted before event processed

### DIFF
--- a/janusgraph-cdc-extension/src/main/java/org/sunbird/janusgraph/cdc/SunbirdLegacyMessageConverter.java
+++ b/janusgraph-cdc-extension/src/main/java/org/sunbird/janusgraph/cdc/SunbirdLegacyMessageConverter.java
@@ -24,6 +24,8 @@ public class SunbirdLegacyMessageConverter implements MessageConverter {
     private static final ObjectMapper mapper = new ObjectMapper();
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
             .withZone(ZoneId.systemDefault());
+    private static final String[] LABEL_KEYS = {"name", "lemma", "title", "gloss"};
+    private static final String[] USER_ID_KEYS = {"lastUpdatedBy", "createdBy"};
 
     // Fields that should remain as JSON strings (loaded from config)
     private static final Set<String> STRING_ONLY_FIELDS = new HashSet<>();
@@ -115,17 +117,26 @@ public class SunbirdLegacyMessageConverter implements MessageConverter {
 
         map.put("transactionData", transactionData);
 
-        // Derived Fields — for DELETE read from the removed-property snapshot since
-        // the vertex is already gone; for CREATE/UPDATE read from the live vertex.
+        // Derived Fields:
+        // - DELETE: read from removed-property snapshot (vertex already gone in this TX)
+        // - UPDATE: read from propertiesMap (transaction log) first, fall back to vertex.
+        //   The vertex may have been deleted by a subsequent transaction before CDC
+        //   processes this one (e.g. publish job: updateProcessingNode → deleteNode).
+        // - CREATE: read from live vertex (just created, always exists)
         boolean isDelete = "DELETE".equals(operationType);
+        boolean isUpdate = "UPDATE".equals(operationType);
         map.put("createdOn", DATE_FORMATTER.format(Instant.now()));
         map.put("channel", isDelete ? getFromSnapshot(deletedProps, "channel", "all")
+                : isUpdate ? getFromPropertiesOrVertex(propertiesMap, vertex, "channel", "all")
                 : getVertexProperty(vertex, "channel", "all"));
         map.put("label", isDelete ? getLabelFromSnapshot(deletedProps, vertex)
+                : isUpdate ? getLabelFromPropertiesOrVertex(propertiesMap, vertex)
                 : getLabel(vertex));
         map.put("nodeType", isDelete ? getFromSnapshot(deletedProps, "IL_SYS_NODE_TYPE", "DATA_NODE")
+                : isUpdate ? getFromPropertiesOrVertex(propertiesMap, vertex, "IL_SYS_NODE_TYPE", "DATA_NODE")
                 : getVertexProperty(vertex, "IL_SYS_NODE_TYPE", "DATA_NODE"));
         String objectType = isDelete ? getFromSnapshot(deletedProps, "IL_FUNC_OBJECT_TYPE", vertex.label())
+                : isUpdate ? getFromPropertiesOrVertex(propertiesMap, vertex, "IL_FUNC_OBJECT_TYPE", vertex.label())
                 : getVertexProperty(vertex, "IL_FUNC_OBJECT_TYPE", vertex.label());
         // Filter out internal JanusGraph vertices that have no IL_FUNC_OBJECT_TYPE set
         // (their label falls back to TinkerPop's default "vertex")
@@ -136,8 +147,11 @@ public class SunbirdLegacyMessageConverter implements MessageConverter {
         }
         map.put("objectType", objectType);
         map.put("nodeUniqueId", isDelete ? getFromSnapshot(deletedProps, "IL_UNIQUE_ID", vertex.id().toString())
+                : isUpdate ? getFromPropertiesOrVertex(propertiesMap, vertex, "IL_UNIQUE_ID", vertex.id().toString())
                 : getVertexProperty(vertex, "IL_UNIQUE_ID", vertex.id().toString()));
-        map.put("userId", isDelete ? getUserIdFromSnapshot(deletedProps, vertex) : getUserId(vertex));
+        map.put("userId", isDelete ? getUserIdFromSnapshot(deletedProps, vertex)
+                : isUpdate ? getUserIdFromPropertiesOrVertex(propertiesMap, vertex)
+                : getUserId(vertex));
 
         // Filter unnecessary events for ROOT node
         // Only if there are NO added/removed relations
@@ -233,7 +247,7 @@ public class SunbirdLegacyMessageConverter implements MessageConverter {
 
     private String getLabel(JanusGraphVertex vertex) {
         // Legacy: name -> lemma -> title -> gloss
-        for (String key : new String[]{"name", "lemma", "title", "gloss"}) {
+        for (String key : LABEL_KEYS) {
             String val = getVertexProperty(vertex, key, null);
             if (val != null) return val;
         }
@@ -241,10 +255,10 @@ public class SunbirdLegacyMessageConverter implements MessageConverter {
     }
 
     private String getUserId(JanusGraphVertex vertex) {
-        String val = getVertexProperty(vertex, "lastUpdatedBy", null);
-        if (val != null) return val;
-        val = getVertexProperty(vertex, "createdBy", null);
-        if (val != null) return val;
+        for (String key : USER_ID_KEYS) {
+            String val = getVertexProperty(vertex, key, null);
+            if (val != null) return val;
+        }
         return "ANONYMOUS";
     }
 
@@ -270,7 +284,7 @@ public class SunbirdLegacyMessageConverter implements MessageConverter {
     }
 
     private String getLabelFromSnapshot(Map<String, Object> snapshot, JanusGraphVertex vertex) {
-        for (String key : new String[]{"name", "lemma", "title", "gloss"}) {
+        for (String key : LABEL_KEYS) {
             Object val = snapshot.get(key);
             if (val != null) return val.toString();
         }
@@ -278,10 +292,41 @@ public class SunbirdLegacyMessageConverter implements MessageConverter {
     }
 
     private String getUserIdFromSnapshot(Map<String, Object> snapshot, JanusGraphVertex vertex) {
-        Object val = snapshot.get("lastUpdatedBy");
-        if (val != null) return val.toString();
-        val = snapshot.get("createdBy");
-        if (val != null) return val.toString();
+        for (String key : USER_ID_KEYS) {
+            Object val = snapshot.get(key);
+            if (val != null) return val.toString();
+        }
+        return "ANONYMOUS";
+    }
+
+    // --- Helpers: read derived fields from propertiesMap (transaction log) first,
+    //     fall back to vertex. Handles race condition where vertex is deleted by a
+    //     subsequent transaction before CDC processes this UPDATE event. ---
+
+    @SuppressWarnings("unchecked")
+    private String getFromPropertiesOrVertex(Map<String, Object> propertiesMap, JanusGraphVertex vertex,
+            String key, String defaultValue) {
+        Object entry = propertiesMap.get(key);
+        if (entry instanceof Map) {
+            Object nv = ((Map<String, Object>) entry).get("nv");
+            if (nv != null) return nv.toString();
+        }
+        return getVertexProperty(vertex, key, defaultValue);
+    }
+
+    private String getLabelFromPropertiesOrVertex(Map<String, Object> propertiesMap, JanusGraphVertex vertex) {
+        for (String key : LABEL_KEYS) {
+            String val = getFromPropertiesOrVertex(propertiesMap, vertex, key, null);
+            if (val != null) return val;
+        }
+        return vertex.label();
+    }
+
+    private String getUserIdFromPropertiesOrVertex(Map<String, Object> propertiesMap, JanusGraphVertex vertex) {
+        for (String key : USER_ID_KEYS) {
+            String val = getFromPropertiesOrVertex(propertiesMap, vertex, key, null);
+            if (val != null) return val;
+        }
         return "ANONYMOUS";
     }
 


### PR DESCRIPTION
## Summary

Fixes a CDC race condition during the second publish cycle where `updateProcessingNode` transaction events are processed **after** the image node (`.img`) has been deleted by a subsequent `deleteNode` transaction.

### Problem

During publish, two transactions execute in quick succession on the image node:
1. `updateProcessingNode` — writes status `Review → Processing` (full property rewrite)
2. `deleteNode` — removes the `.img` vertex entirely

CDC processes transaction log entries asynchronously. When it processes the `updateProcessingNode` event **after** the vertex is already deleted:
- `vertex.properties()` returns defaults (vertex gone)
- `vertex.label()` returns `"vertex"` (TinkerPop default)
- `vertex.id().toString()` returns internal graph ID (e.g. `"1024004192"`) instead of `do_xxx.img`

This produces garbage events with `objectType: "vertex"` and numeric `nodeUniqueId`, causing the downstream transaction-event-processor to crash with:
```
FileNotFoundException: schemas/local/vertex/1.0/schema.json
```

### Fix

**For UPDATE events**, derived fields (`objectType`, `nodeUniqueId`, `channel`, `nodeType`, `label`, `userId`) are now read from `propertiesMap` (transaction log data) first, falling back to vertex state only if not present in the transaction.

- `propertiesMap` is built from `ChangeState` (immutable transaction log) — always accurate regardless of current vertex state
- Added `getFromPropertiesOrVertex()` helper and refactored `getLabelFromPropertiesOrVertex()` / `getUserIdFromPropertiesOrVertex()` to reuse it
- Extracted `LABEL_KEYS` and `USER_ID_KEYS` as static constants

**Safety net**: Events with `objectType="vertex"` (no `IL_FUNC_OBJECT_TYPE` set) are filtered out and return `null` — CDC skips them entirely.

### Event flow (before vs after fix)

```
Before:  updateProcessingNode TX → vertex deleted → CDC reads vertex → objectType="vertex", nodeUniqueId="1024004192" → CRASH
After:   updateProcessingNode TX → vertex deleted → CDC reads propertiesMap → objectType="CollectionImage", nodeUniqueId from TX log → OK
```

> **Note:** A companion fix in `knowledge-platform-jobs` (ObjectUpdater.scala) adds `IL_UNIQUE_ID` to the `updateProcessingNode` metadata map, ensuring `nodeUniqueId` is always available in `propertiesMap` even when the vertex is deleted.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Deployed to test environment and ran full second publish cycle (Create → Review → Publish → Update → Review → Publish)
- [x] Verified CDC events have correct `objectType` and `nodeUniqueId` for image node transactions
- [x] Verified transaction-event-processor no longer crashes with `vertex` schema error
- [x] Verified first publish cycle (no image node) unaffected

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings