### PR TITLE
fix: stop persisting CDC processor read marker across restarts

### DIFF
--- a/janusgraph-cdc-extension/src/main/java/org/sunbird/janusgraph/cdc/GraphLogProcessor.java
+++ b/janusgraph-cdc-extension/src/main/java/org/sunbird/janusgraph/cdc/GraphLogProcessor.java
@@ -106,8 +106,17 @@ public class GraphLogProcessor {
 
         try {
             LogProcessorFramework framework = JanusGraphFactory.openTransactionLog(graph);
+            // No setProcessorIdentifier(): an identified processor persists its read
+            // marker and resumes it on every restart, ignoring setStartTime() after the
+            // first run. That forces replay of old/backlogged transaction-log entries on
+            // every JanusGraph restart, and vertex property lookups on those replayed
+            // entries come back empty (JanusGraph/storage limitation), which makes
+            // SunbirdLegacyMessageConverter treat every backlogged vertex as
+            // objectType="vertex" and filter it out — i.e. CDC silently stops emitting
+            // events after any stop/start. Staying unidentified means we always start
+            // fresh from setStartTime() below, trading "replay the outage window" for
+            // "CDC actually works after a restart."
             framework.addLogProcessor(LOG_IDENTIFIER)
-                    .setProcessorIdentifier("janusgraph-cdc-processor")
                     .setStartTime(Instant.now().minus(1, ChronoUnit.MINUTES))
                     .addProcessor(new ChangeProcessor() {
                         @Override


### PR DESCRIPTION
## Summary

`GraphLogProcessor.init()` registers the transaction-log processor with `setProcessorIdentifier("janusgraph-cdc-processor")`. An identified log processor persists its read marker in JanusGraph and resumes from it on every subsequent restart — silently ignoring `setStartTime()` after the very first run.

## Root cause

Every JanusGraph stop/start replays old/backlogged transaction-log entries because of the persisted marker. Vertex property lookups (e.g. `IL_FUNC_OBJECT_TYPE`) performed on vertex handles bound to a replayed historical transaction come back empty — this appears to be a JanusGraph/storage-backend limitation when reading properties outside the specific transaction's own change-set. `SunbirdLegacyMessageConverter` falls back to `vertex.label()` (JanusGraph's generic `"vertex"` label) when that lookup is empty, which then hits the existing filter:

```java
if ("vertex".equalsIgnoreCase(objectType)) {
    logger.debug("Skipping event for vertex {} with objectType='vertex' (no IL_FUNC_OBJECT_TYPE set)", vertex.id());
    return null;
}
```

Net effect: after any JanusGraph restart, every backlogged event is filtered out, and CDC silently stops producing anything until the backlog fully drains (which itself takes a long time and can appear to "never recover" on clusters with a large accumulated transaction-log history, e.g. after a disaster-recovery restore).

Reproduced and confirmed via debug logging on a live cluster: the marker loaded on restart showed `Loaded identified ReadMarker start time <stale timestamp>` instead of `now`, and every processed message hit `Event filtered by converter for node <id>` — 100% filter rate, including on messages only minutes old (i.e. not a formatting/legacy-data issue, purely a replay-vs-live distinction).

## Fix

Remove `.setProcessorIdentifier(...)`. Without an identifier, the log processor never persists a marker, so it always starts fresh from `setStartTime()` (`now - 1 minute`) on every restart. This trades replaying the exact outage window for CDC actually continuing to work after a restart — the correct tradeoff for a live content-indexing pipeline where a live/current pipeline matters more than a complete historical replay.

## Test plan

- [ ] Deploy to a test JanusGraph instance with the CDC extension enabled
- [ ] Create/update content, confirm CDC event appears in the configured sink
- [ ] Stop and restart the JanusGraph pod
- [ ] Create/update new content immediately after restart, confirm the event still appears (this is the case that was broken before this fix)
- [ ] Confirm no persisted marker is created for `janusgraph-cdc-processor` in the backend after this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change-data-capture recovery after restarts.
  * CDC now replays events from the configured start time instead of resuming from a persisted read position, helping prevent missed backlog events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->